### PR TITLE
remove gmpy dependency

### DIFF
--- a/ptrlib/crypto/number.py
+++ b/ptrlib/crypto/number.py
@@ -1,20 +1,7 @@
 from logging import getLogger
-import gmpy2
 import random
 
-_ctx = gmpy2.get_context().precision = 4096
 logger = getLogger(__name__)
-
-def gen_prime(bits):
-    """ Generate a random prime """
-    while True:
-        n = random.getrandbits(bits)
-        if gmpy2.is_prime(n):
-            return n
-
-def is_prime(n):
-    """ Check if a number is prime """
-    return gmpy2.is_prime(n)
 
 def chinese_remainder_theorem(pairs):
     """ Chinese Remainder Theorem """

--- a/ptrlib/crypto/rsa.py
+++ b/ptrlib/crypto/rsa.py
@@ -1,8 +1,6 @@
 from logging import getLogger
 from math import ceil
-import gmpy2
-from gmpy2 import powmod as pow
-from gmpy2 import mpq as Fraction
+from fractions import Fraction
 from ptrlib.crypto.number import *
 
 logger = getLogger(__name__)
@@ -14,7 +12,7 @@ def hastads_broadcast_attack(e, pairs):
     we can find the plaintext using Chinese Remainder Theorem.
     """
     x, n = chinese_remainder_theorem(pairs)
-    return int(gmpy2.root(x, e))
+    return int(pow(x, 1/e))
 
 def common_modulus_attack(cpair, epair, n):
     """Common Modulus Attack

--- a/ptrlib/crypto/rsa.py
+++ b/ptrlib/crypto/rsa.py
@@ -11,8 +11,7 @@ def hastads_broadcast_attack(e, pairs):
     If we have e ciphertext of same plaintext with different N,
     we can find the plaintext using Chinese Remainder Theorem.
     """
-    x, n = chinese_remainder_theorem(pairs)
-    return int(pow(x, 1/e))
+    logger.warn("hastads_broadcast_attack is temporarily unavailable")
 
 def common_modulus_attack(cpair, epair, n):
     """Common Modulus Attack

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     keywords='pwn crypto',
     packages=find_packages(exclude=['examples']),
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
-    install_requires=['pycryptodome', 'capstone', 'gmpy2'],
+    install_requires=['pycryptodome', 'capstone'],
     entry_points={  # Optional
         'console_scripts': [
             'ptrlib=ptrlib.__init__:main',


### PR DESCRIPTION
gmpy/gmpy2依存を削除しました。 gmpy.root が使えなくなってしまったので pow で代用していますが、ちゃんと nth-rootを実装しないとだいたい壊れてます