### PR TITLE
Add check for return value of self.is_alive() in proc.close()

### DIFF
--- a/ptrlib/connection/proc.py
+++ b/ptrlib/connection/proc.py
@@ -195,12 +195,15 @@ class UnixProcess(Tube):
         """
         if self.proc:
             os.close(self.slave)
-            self.proc.stdin.close()
+            if self.is_alive():
+                self.proc.stdin.close()
+                logger.info("'{0}' (PID={1}) killed".format(self.filepath, self.proc.pid))
+            else:
+                logger.info("'{0}' (PID={1}) has alrealy exited".format(self.filepath, self.proc.pid))
             self.proc.stdout.close()
             self.proc.kill()
             self.proc.wait()
             self.proc = None
-            logger.info("'{0}' killed".format(self.filepath))
 
     def shutdown(self, target: Literal['send', 'recv']):
         """Kill one connection

--- a/ptrlib/connection/proc.py
+++ b/ptrlib/connection/proc.py
@@ -204,7 +204,7 @@ class UnixProcess(Tube):
                 self.proc = None
             else:
                 self.proc.stdout.close()
-                logger.info("'{0}' (PID={1}) has alrealy exited".format(self.filepath, self.proc.pid))
+                logger.info("'{0}' (PID={1}) has already exited".format(self.filepath, self.proc.pid))
                 self.proc = None
 
     def shutdown(self, target: Literal['send', 'recv']):

--- a/ptrlib/connection/proc.py
+++ b/ptrlib/connection/proc.py
@@ -197,13 +197,15 @@ class UnixProcess(Tube):
             os.close(self.slave)
             if self.is_alive():
                 self.proc.stdin.close()
+                self.proc.stdout.close()
+                self.proc.kill()
+                self.proc.wait()
+                self.proc = None
                 logger.info("'{0}' (PID={1}) killed".format(self.filepath, self.proc.pid))
             else:
+                self.proc.stdout.close()
+                self.proc = None
                 logger.info("'{0}' (PID={1}) has alrealy exited".format(self.filepath, self.proc.pid))
-            self.proc.stdout.close()
-            self.proc.kill()
-            self.proc.wait()
-            self.proc = None
 
     def shutdown(self, target: Literal['send', 'recv']):
         """Kill one connection

--- a/ptrlib/connection/proc.py
+++ b/ptrlib/connection/proc.py
@@ -200,12 +200,12 @@ class UnixProcess(Tube):
                 self.proc.stdout.close()
                 self.proc.kill()
                 self.proc.wait()
-                self.proc = None
                 logger.info("'{0}' (PID={1}) killed".format(self.filepath, self.proc.pid))
+                self.proc = None
             else:
                 self.proc.stdout.close()
-                self.proc = None
                 logger.info("'{0}' (PID={1}) has alrealy exited".format(self.filepath, self.proc.pid))
+                self.proc = None
 
     def shutdown(self, target: Literal['send', 'recv']):
         """Kill one connection


### PR DESCRIPTION
# Add check for return value of self.is_alive() in proc.close()
## What's this Pull Request for?
Choose one or more of the following items.

- [x] Bug fix
- [ ] Add/Remove feature
- [ ] Cleaning code (including optimization/typo fix)
- [ ] Others

Please explain the detail here:
If a destructor is executed after an attempt to input to a program that has already exited by Segmentation Fault, etc, an BrokenPipeError occur in self.proc.stdin.close() because the pipe is broken.

```
Exception ignored in: <function UnixProcess.__del__ at 0x7f39571ce160>
Traceback (most recent call last):
  File "/home/vagrant/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ptrlib/connection/proc.py", line 235, in __del__
    self.close()
  File "/home/vagrant/.pyenv/versions/3.11.3/lib/python3.11/site-packages/ptrlib/connection/proc.py", line 198, in close
    self.proc.stdin.close()
BrokenPipeError: [Errno 32] Broken pipe
```

## What have you done so far?
Tell me what you've tested to assure your change is right.

- [x] All tests passed on your machine (`python -m unittest`)
- [ ] Added test cases for new feature
- [ ] Nothing / Test not required

(It's not mandatory to check even one of them, but test cases make it easy for the author to review your PR.)

## Comment
Error reproduction
https://github.com/tsg-ut/tsg-live-ctf-10/blob/master/pwn/renewal/solver/renewal.py

pwntoolsではEOFErrorを使っていましたが、ptrlibではraiseしていないのでTimeoutErrorを使ってみました。これが正攻法なのかもっといい方法があるのか教えてくださると嬉しいです。
self.proc関連のメソッドはif elseの内部に入れた方が読みやすいと思ってまとめてみましたが、コードの重複があります。
self.proc.kill()とself.proc.wait()は、既に対象プログラムがexitした状態ではSIGKILLを送る必要はないと考えてelseの中に入れていませんが、間違っていたら変えてください。