### PR TITLE
Fix ELF Parser size bug and Re-enable test_elf_*.py tests for Windows

### DIFF
--- a/ptrlib/filestruct/bunkai.py
+++ b/ptrlib/filestruct/bunkai.py
@@ -230,22 +230,22 @@ class BunkaiPrimitive(object):
         else:
             return self._ty.from_buffer_copy(buf).value
 
-u8  = BunkaiPrimitive(ctypes.c_ubyte)
-u16 = BunkaiPrimitive(ctypes.c_ushort)
-u32 = BunkaiPrimitive(ctypes.c_uint)
-u64 = BunkaiPrimitive(ctypes.c_ulong)
-s8  = BunkaiPrimitive(ctypes.c_byte)
-s16 = BunkaiPrimitive(ctypes.c_short)
-s32 = BunkaiPrimitive(ctypes.c_int)
-s64 = BunkaiPrimitive(ctypes.c_long)
-u8be  = BunkaiPrimitive(ctypes.c_ubyte, True)
-u16be = BunkaiPrimitive(ctypes.c_ushort, True)
-u32be = BunkaiPrimitive(ctypes.c_uint, True)
-u64be = BunkaiPrimitive(ctypes.c_ulong, True)
-s8be  = BunkaiPrimitive(ctypes.c_byte, True)
-s16be = BunkaiPrimitive(ctypes.c_short, True)
-s32be = BunkaiPrimitive(ctypes.c_int, True)
-s64be = BunkaiPrimitive(ctypes.c_long, True)
+u8  = BunkaiPrimitive(ctypes.c_uint8)
+u16 = BunkaiPrimitive(ctypes.c_uint16)
+u32 = BunkaiPrimitive(ctypes.c_uint32)
+u64 = BunkaiPrimitive(ctypes.c_uint64)
+s8  = BunkaiPrimitive(ctypes.c_int8)
+s16 = BunkaiPrimitive(ctypes.c_int16)
+s32 = BunkaiPrimitive(ctypes.c_int32)
+s64 = BunkaiPrimitive(ctypes.c_int64)
+u8be  = BunkaiPrimitive(ctypes.c_uint8, True)
+u16be = BunkaiPrimitive(ctypes.c_uint16, True)
+u32be = BunkaiPrimitive(ctypes.c_uint32, True)
+u64be = BunkaiPrimitive(ctypes.c_uint64, True)
+s8be  = BunkaiPrimitive(ctypes.c_int8, True)
+s16be = BunkaiPrimitive(ctypes.c_int16, True)
+s32be = BunkaiPrimitive(ctypes.c_int32, True)
+s64be = BunkaiPrimitive(ctypes.c_int64, True)
 
 if __name__ == '__main__':
     data  = b'\xde\xad\xbe\xef' # magic

--- a/tests/filestruct/elf/test_elf_1.py
+++ b/tests/filestruct/elf/test_elf_1.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/libc-2.27.so"
 BASE = 0x7fffdeadb000
@@ -12,8 +10,6 @@ BASE = 0x7fffdeadb000
 class TestELF1(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_symbol(self):

--- a/tests/filestruct/elf/test_elf_2.py
+++ b/tests/filestruct/elf/test_elf_2.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/libc-2.31.so"
 BASE = 0x7fffdeadb000
@@ -12,8 +10,6 @@ BASE = 0x7fffdeadb000
 class TestELF2(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_symbol(self):

--- a/tests/filestruct/elf/test_elf_3.py
+++ b/tests/filestruct/elf/test_elf_3.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/libc-2.34.so"
 BASE = 0x7fffdeadb000
@@ -12,8 +10,6 @@ BASE = 0x7fffdeadb000
 class TestELF3(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_symbol(self):

--- a/tests/filestruct/elf/test_elf_4.py
+++ b/tests/filestruct/elf/test_elf_4.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/test_echo.x86"
 BASE = 0x7fdea000
@@ -12,8 +10,6 @@ BASE = 0x7fdea000
 class TestELF4(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_plt(self):

--- a/tests/filestruct/elf/test_elf_5.py
+++ b/tests/filestruct/elf/test_elf_5.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/test_echo.x64"
 BASE = 0x555555554000
@@ -12,8 +10,6 @@ BASE = 0x555555554000
 class TestELF5(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_plt(self):

--- a/tests/filestruct/elf/test_elf_6.py
+++ b/tests/filestruct/elf/test_elf_6.py
@@ -3,16 +3,12 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/test_fsb.x86"
 
 class TestELF6(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_plt(self):

--- a/tests/filestruct/elf/test_elf_7.py
+++ b/tests/filestruct/elf/test_elf_7.py
@@ -3,16 +3,12 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/test_fsb.x64"
 
 class TestELF7(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_plt(self):

--- a/tests/filestruct/elf/test_elf_8.py
+++ b/tests/filestruct/elf/test_elf_8.py
@@ -3,16 +3,12 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/test_plt.x64"
 
 class TestELF8(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_plt(self):

--- a/tests/filestruct/elf/test_elf_9.py
+++ b/tests/filestruct/elf/test_elf_9.py
@@ -3,8 +3,6 @@ import os
 from ptrlib.filestruct.elf import ELF
 from logging import getLogger, FATAL
 
-_is_windows = os.name == 'nt'
-
 
 PATH_ELF = "./tests/test.bin/libc-2.35.so"
 BASE = 0x7fffdeadb000
@@ -12,8 +10,6 @@ BASE = 0x7fffdeadb000
 class TestELF9(unittest.TestCase):
     def setUp(self):
         getLogger("ptrlib").setLevel(FATAL)
-        if _is_windows:
-            self.skipTest("This test is intended for the Linux platform")
         self.elf = ELF(PATH_ELF)
 
     def test_symbol(self):


### PR DESCRIPTION
# Fix ELF Parser size bug and Re-enable test_elf_*.py tests for Windows
## What's this Pull Request for?
Choose one or more of the following items.

- [x] Bug fix
- [ ] Add/Remove feature
- [ ] Cleaning code (including optimization/typo fix)
- [ ] Others

Please explain the detail here:
This pull request fixes an ELF parser size bug, which was causing some `test_elf_*.py` tests to fail. It does so by using implementation-independent integer types in BunkaiPrimitive. And also reverts the `test_elf_*.py` tests for Windows.

The root cause of this issue is the difference in the sizeof types like long across different platforms:

On x64 Windows 11:
```
Python 3.12.2 (tags/v3.12.2:6abddd9, Feb  6 2024, 21:26:36) [MSC v.1937 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import ctypes
>>> ctypes.sizeof(ctypes.c_ulong)
4
```

On x64 Ubuntu:
```
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ctypes
>>> ctypes.sizeof(ctypes.c_ulong)
8
```

## What have you done so far?
Tell me what you've tested to assure your change is right.

- [x] All tests passed on your machine (`python -m unittest`)
- [ ] Added test cases for new feature
- [ ] Nothing / Test not required

(It's not mandatory to check even one of them, but test cases make it easy for the author to review your PR.)

## Comment
