### PR TITLE
Update recvuntil

### DIFF
--- a/ptrlib/connection/tube.py
+++ b/ptrlib/connection/tube.py
@@ -157,19 +157,22 @@ class Tube(metaclass=ABCMeta):
 
         found = False
         token = None
-        while not found:
+        while True:
             try:
                 data += self.recv(size, timeout=-1)
             except TimeoutError as err:
                 raise TimeoutError("`recvuntil` timeout", data + err.args[1])
-            if sleep_time > 0:
-                time.sleep(sleep_time)
 
             for t in delim:
                 if t in data:
                     found = True
                     token = t
                     break
+
+            if found:
+                break
+            if sleep_time:
+                time.sleep(sleep_time)
 
         found_pos = data.find(token)
         result_len = found_pos if drop else found_pos + len(token)

--- a/ptrlib/connection/tube.py
+++ b/ptrlib/connection/tube.py
@@ -122,7 +122,8 @@ class Tube(metaclass=ABCMeta):
                   size: int=4096,
                   timeout: Optional[Union[int, float]]=None,
                   drop: bool=False,
-                  lookahead: bool=False) -> bytes:
+                  lookahead: bool=False,
+                  sleep_time: float=0.01) -> bytes:
         """Receive raw data until `delim` comes
 
         Args:
@@ -131,6 +132,7 @@ class Tube(metaclass=ABCMeta):
             timeout (int): Timeout (in second)
             drop (bool): Discard delimiter or not
             lookahead (bool): Unget delimiter to buffer or not
+            sleep_time (float): Sleep time after receiving data
 
         Returns:
             bytes: Received data
@@ -160,7 +162,8 @@ class Tube(metaclass=ABCMeta):
                 data += self.recv(size, timeout=-1)
             except TimeoutError as err:
                 raise TimeoutError("`recvuntil` timeout", data + err.args[1])
-            time.sleep(0.01)
+            if sleep_time > 0:
+                time.sleep(sleep_time)
 
             for t in delim:
                 if t in data:


### PR DESCRIPTION
# Update recvuntil
## What's this Pull Request for?
Choose one or more of the following items.

- [x] Bug fix
- [x] Add/Remove feature
- [ ] Cleaning code (including optimization/typo fix)
- [ ] Others

Please explain the detail here:
Bug fix: Do not sleep when received the delim.
Feat: Added sleep_time argument.

## What have you done so far?
Tell me what you've tested to assure your change is right.

- [x] All tests passed on your machine (`python -m unittest`)
- [ ] Added test cases for new feature
- [ ] Nothing / Test not required
(It's not mandatory to check even one of them, but test cases make it easy for the author to review your PR.)

## Comment
`recvuntil`が成功したかどうかに関わらず`sleep(0.01)`を挟むのはパフォーマンス上の問題があるので、成功した際には`sleep`を行なわないようにしました。また、`sleep`の長さを引数で設定できる様にしました。

疑問点としてそもそも`delim`が返ってくるまで`recv(size, timeout=-1)`を回しているのでここでブロッキングが起こるはずで、追加で`sleep`
を入れる理由が分かりませんでした。