### PR TITLE
Fix SNI Handling in Socket class when sni is unspecified

### DIFF
--- a/ptrlib/connection/sock.py
+++ b/ptrlib/connection/sock.py
@@ -68,8 +68,10 @@ class Socket(Tube):
             self.context = _ssl.SSLContext(_ssl.PROTOCOL_TLS_CLIENT)
             self.context.check_hostname = False
             self.context.verify_mode = _ssl.CERT_NONE
-            if sni is True:
+            if not sni:
                 self._sock = self.context.wrap_socket(self._sock)
+            elif sni is True:
+                self._sock = self.context.wrap_socket(self._sock, server_hostname=host)
             else:
                 self._sock = self.context.wrap_socket(self._sock, server_hostname=sni)
 

--- a/tests/connection/test_sock.py
+++ b/tests/connection/test_sock.py
@@ -58,7 +58,8 @@ class TestSocket(unittest.TestCase):
         sock.close()
 
         # connect with a specific SNI value
-        sock = Socket(host, 443, ssl=True, sni="example.com")
+        ip_addr = gethostbyname(host)
+        sock = Socket(ip_addr, 443, ssl=True, sni="example.com")
         sock.sendline(f'GET {path} HTTP/1.1'.encode() + b'\r')
         sock.send(f'Host: {host}'.encode() + b'\r\n')
         sock.send(b'Connection: close\r\n\r\n')


### PR DESCRIPTION
# Fix SNI Handling in Socket class when sni is unspecified
## What's this Pull Request for?
Choose one or more of the following items.

- [x] Bug fix
- [ ] Add/Remove feature
- [ ] Cleaning code (including optimization/typo fix)
- [ ] Others

Please explain the detail here:
Fixes an issue where SNI was not enabled when `ssl=True` was specified in the Socket without explicitly specifying SNI.
In testing, uses the site (https://check-tls.akamaized.net/v1/tlssni.json), which returns the SNI status of the request.

## What have you done so far?
Tell me what you've tested to assure your change is right.

- [x] All tests passed on your machine (`python -m unittest`)
- [x] Added test cases for new feature
- [ ] Nothing / Test not required

(It's not mandatory to check even one of them, but test cases make it easy for the author to review your PR.)

## Comment
