### PR TITLE
Added methods that retrieves the corresponding bytes by specifying a virtual address.

### DIFF
--- a/ptrlib/filestruct/elf/elf.py
+++ b/ptrlib/filestruct/elf/elf.py
@@ -259,7 +259,7 @@ class ELF(object):
         for result in self.search(pattern, writable, executable):
             yield result
     
-    def addr2offset(self, addr: int) -> int | None:
+    def addr2offset(self, addr: int) -> Optional[int]:
         """Returns the offset in the ELF corresponding to a given virtual address.
 
         Args:
@@ -285,7 +285,7 @@ class ELF(object):
 
         return None
 
-    def read(self, addr: int, size: int) -> bytes | None:
+    def read(self, addr: int, size: int) -> Optional[bytes]:
         """Returns the bytes of a size from a virtual address.
 
         If a non-existent address is specified, None is returned.

--- a/ptrlib/filestruct/elf/elf.py
+++ b/ptrlib/filestruct/elf/elf.py
@@ -263,7 +263,10 @@ class ELF(object):
         """Returns the offset in the ELF corresponding to a given virtual address.
 
         Args:
-            addr (int): Address
+            addr (int): Virtual address.
+        
+        Returns:
+            int | None: Offset. If a non-existent address is specified, None is returned
         """
         parser = self._parser
 
@@ -290,11 +293,11 @@ class ELF(object):
         Unintended behaviour will occur if the segment is crossed.
 
         Args:
-            addr (int): Start address
+            addr (int): Start virtual address
             size (int): Size of bytes
 
         Returns:
-            bytes: bytes in the file
+            bytes | None: Bytes in the file. If a non-existent address is specified, None is returned
         """
         parser = self._parser
 
@@ -302,14 +305,14 @@ class ELF(object):
 
         if offset is not None:
             stream = parser.stream
-            # save pointer
+            # save position
             current_offset = stream.tell()
 
             # get bytes
             stream.seek(offset)
             ret = stream.read(size)
 
-            # recover pointer
+            # recover position
             stream.seek(current_offset)
 
             return ret
@@ -320,6 +323,15 @@ class ELF(object):
     def read_by_range(self, start: int, end: int) -> bytes | None:
         """
         Returns the bytes from a start virtual address to an end virtual address.
+
+        Just doing `elf.read(start, end-start)`
+
+        Args:
+            start (int): Start virtual address
+            end (int): End virtual address
+
+        Returns:
+            bytes | None: Bytes in the file. If a non-existent address is specified, None is returned
         """
         size = end - start
         return self.read(start, size)

--- a/ptrlib/filestruct/elf/elf.py
+++ b/ptrlib/filestruct/elf/elf.py
@@ -319,23 +319,6 @@ class ELF(object):
         
         return None
 
-    # return bytes of elf by `range (b[start:end])`
-    def read_by_range(self, start: int, end: int) -> bytes | None:
-        """
-        Returns the bytes from a start virtual address to an end virtual address.
-
-        Just doing `elf.read(start, end-start)`
-
-        Args:
-            start (int): Start virtual address
-            end (int): End virtual address
-
-        Returns:
-            bytes | None: Bytes in the file. If a non-existent address is specified, None is returned
-        """
-        size = end - start
-        return self.read(start, size)
-
     def plt(self, name: Union[str, bytes]) -> Optional[int]:
         """Get a PLT address
         Lookup the PLT table and find the corresponding address

--- a/tests/filestruct/elf/test_elf_1.py
+++ b/tests/filestruct/elf/test_elf_1.py
@@ -45,6 +45,14 @@ class TestELF1(unittest.TestCase):
         self.assertEqual(next(self.elf.search('A', writable=True)), BASE + 4099264)
         self.assertEqual(next(self.elf.find(b'/bin/sh\0')), BASE + 1785498)
 
+    def test_read(self):
+        # syscall function
+        self.assertEqual(self.elf.read(0x11b820, 0x33), b"H\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\x1f\xf6,\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3")
+        self.assertEqual(self.elf.read_by_range(0x11b820, 0x11b820+0x33), b"H\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\x1f\xf6,\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3")
+        # "/bin/sh"
+        self.assertEqual(self.elf.read(1785498, 8), b"/bin/sh\0")
+        self.assertEqual(self.elf.read_by_range(1785498, 1785498 + 8), b"/bin/sh\0")
+
     def test_main_arena(self):
         self.elf.base = 0
         self.assertEqual(self.elf.main_arena(), 0x3ebc40)

--- a/tests/filestruct/elf/test_elf_1.py
+++ b/tests/filestruct/elf/test_elf_1.py
@@ -48,10 +48,8 @@ class TestELF1(unittest.TestCase):
     def test_read(self):
         # syscall function
         self.assertEqual(self.elf.read(0x11b820, 0x33), b"H\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\x1f\xf6,\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3")
-        self.assertEqual(self.elf.read_by_range(0x11b820, 0x11b820+0x33), b"H\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\x1f\xf6,\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3")
         # "/bin/sh"
         self.assertEqual(self.elf.read(1785498, 8), b"/bin/sh\0")
-        self.assertEqual(self.elf.read_by_range(1785498, 1785498 + 8), b"/bin/sh\0")
 
     def test_main_arena(self):
         self.elf.base = 0

--- a/tests/filestruct/elf/test_elf_10.py
+++ b/tests/filestruct/elf/test_elf_10.py
@@ -45,6 +45,18 @@ class TestELF10(unittest.TestCase):
         self.assertEqual(next(self.elf.search('A', writable=True)), BASE + 0x22fb8c)
         self.assertEqual(next(self.elf.find(b'/bin/sh\0')), BASE + 0x1c4de8)
 
+    def test_read(self):
+        # syscall function
+        start = 0x121a50
+        size = 0x37
+        code = b"UWVS\x8bl$,\x8b|$(\x8bt$$\x8bT$ \x8bL$\x1c\x8b\\$\x18\x8bD$\x14e\xff\x15\x10\x00\x00\x00[^_]=\x01\xf0\xff\xff\x0f\x83\xda3\xf0\xff\xc3"
+        self.assertEqual(self.elf.read(start, size), code)
+        self.assertEqual(self.elf.read_by_range(start, start + size), code)
+        # "/bin/sh"
+        start = 0x1c4de8
+        self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
+        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
+
     def test_main_arena(self):
         self.elf.base = 0
         self.assertEqual(self.elf.main_arena(), 0x231760)

--- a/tests/filestruct/elf/test_elf_10.py
+++ b/tests/filestruct/elf/test_elf_10.py
@@ -51,11 +51,9 @@ class TestELF10(unittest.TestCase):
         size = 0x37
         code = b"UWVS\x8bl$,\x8b|$(\x8bt$$\x8bT$ \x8bL$\x1c\x8b\\$\x18\x8bD$\x14e\xff\x15\x10\x00\x00\x00[^_]=\x01\xf0\xff\xff\x0f\x83\xda3\xf0\xff\xc3"
         self.assertEqual(self.elf.read(start, size), code)
-        self.assertEqual(self.elf.read_by_range(start, start + size), code)
         # "/bin/sh"
         start = 0x1c4de8
         self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
-        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
 
     def test_main_arena(self):
         self.elf.base = 0

--- a/tests/filestruct/elf/test_elf_2.py
+++ b/tests/filestruct/elf/test_elf_2.py
@@ -51,10 +51,8 @@ class TestELF2(unittest.TestCase):
         size = 0x37
         code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\xf36\r\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
         self.assertEqual(self.elf.read(start, size), code)
-        self.assertEqual(self.elf.read_by_range(start, start + size), code)
         # "/bin/sh"
         self.assertEqual(self.elf.read(1787325, 8), b"/bin/sh\0")
-        self.assertEqual(self.elf.read_by_range(1787325, 1787325 + 8), b"/bin/sh\0")
 
     def test_main_arena(self):
         self.elf.base = 0

--- a/tests/filestruct/elf/test_elf_2.py
+++ b/tests/filestruct/elf/test_elf_2.py
@@ -45,6 +45,17 @@ class TestELF2(unittest.TestCase):
         self.assertEqual(next(self.elf.search('A', writable=True)), BASE + 2004929)
         self.assertEqual(next(self.elf.find(b'/bin/sh\0')), BASE + 1787325)
 
+    def test_read(self):
+        # syscall function
+        start = 0x118750
+        size = 0x37
+        code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\xf36\r\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
+        self.assertEqual(self.elf.read(start, size), code)
+        self.assertEqual(self.elf.read_by_range(start, start + size), code)
+        # "/bin/sh"
+        self.assertEqual(self.elf.read(1787325, 8), b"/bin/sh\0")
+        self.assertEqual(self.elf.read_by_range(1787325, 1787325 + 8), b"/bin/sh\0")
+
     def test_main_arena(self):
         self.elf.base = 0
         self.assertEqual(self.elf.main_arena(), 0x1ecb80)

--- a/tests/filestruct/elf/test_elf_3.py
+++ b/tests/filestruct/elf/test_elf_3.py
@@ -45,6 +45,18 @@ class TestELF3(unittest.TestCase):
         self.assertEqual(next(self.elf.search('A', writable=True)), BASE + 2187072)
         self.assertEqual(next(self.elf.find(b'/bin/sh\0')), BASE + 1948858)
 
+    def test_read(self):
+        # syscall function
+        start = 0x121930
+        size = 0x37
+        code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\xb3d\x0f\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
+        self.assertEqual(self.elf.read(start, size), code)
+        self.assertEqual(self.elf.read_by_range(start, start + size), code)
+        # "/bin/sh"
+        start = 1948858
+        self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
+        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
+
     def test_main_arena(self):
         self.elf.base = 0
         self.assertEqual(self.elf.main_arena(), 0x218c60)

--- a/tests/filestruct/elf/test_elf_3.py
+++ b/tests/filestruct/elf/test_elf_3.py
@@ -51,11 +51,9 @@ class TestELF3(unittest.TestCase):
         size = 0x37
         code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\r\xb3d\x0f\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
         self.assertEqual(self.elf.read(start, size), code)
-        self.assertEqual(self.elf.read_by_range(start, start + size), code)
         # "/bin/sh"
         start = 1948858
         self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
-        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
 
     def test_main_arena(self):
         self.elf.base = 0

--- a/tests/filestruct/elf/test_elf_9.py
+++ b/tests/filestruct/elf/test_elf_9.py
@@ -45,6 +45,18 @@ class TestELF9(unittest.TestCase):
         self.assertEqual(next(self.elf.search('A', writable=True)), BASE + 0x219529)
         self.assertEqual(next(self.elf.find(b'/bin/sh\0')), BASE + 0x1d8678)
 
+    def test_read(self):
+        # syscall function
+        start = 0x11e870
+        size = 0x37
+        code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\rs\xb5\x0f\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
+        self.assertEqual(self.elf.read(start, size), code)
+        self.assertEqual(self.elf.read_by_range(start, start + size), code)
+        # "/bin/sh"
+        start = 0x1d8678
+        self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
+        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
+
     def test_main_arena(self):
         self.elf.base = 0
         self.assertEqual(self.elf.main_arena(), 0x21ac80)

--- a/tests/filestruct/elf/test_elf_9.py
+++ b/tests/filestruct/elf/test_elf_9.py
@@ -51,11 +51,9 @@ class TestELF9(unittest.TestCase):
         size = 0x37
         code = b"\xf3\x0f\x1e\xfaH\x89\xf8H\x89\xf7H\x89\xd6H\x89\xcaM\x89\xc2M\x89\xc8L\x8bL$\x08\x0f\x05H=\x01\xf0\xff\xffs\x01\xc3H\x8b\rs\xb5\x0f\x00\xf7\xd8d\x89\x01H\x83\xc8\xff\xc3"
         self.assertEqual(self.elf.read(start, size), code)
-        self.assertEqual(self.elf.read_by_range(start, start + size), code)
         # "/bin/sh"
         start = 0x1d8678
         self.assertEqual(self.elf.read(start, 8), b"/bin/sh\0")
-        self.assertEqual(self.elf.read_by_range(start, start + 8), b"/bin/sh\0")
 
     def test_main_arena(self):
         self.elf.base = 0


### PR DESCRIPTION
# Added methods that retrieves the corresponding bytes by specifying a virtual address.
## What's this Pull Request for?
Choose one or more of the following items.

- [ ] Bug fix
- [x] Add/Remove feature
- [ ] Cleaning code (including optimization/typo fix)
- [ ] Others

Please explain the detail here:

**[ja (for author)]**
仮想アドレスを指定すると該当するバイト列を取得するメソッドを追加しました。

**[en (for other contributers)]**
Added methods that retrieves the corresponding bytes by specifying a virtual address.

## What have you done so far?
Tell me what you've tested to assure your change is right.

- [x] All tests passed on your machine (`python -m unittest`)
- [x] Added test cases for new feature
- [ ] Nothing / Test not required

(It's not mandatory to check even one of them, but test cases make it easy for the author to review your PR.)

## Comment
